### PR TITLE
fix: rename VLLMLogprobsCalculator to VLLMLogprobsExtractionCalculator

### DIFF
--- a/scripts/run_tts_eval.py
+++ b/scripts/run_tts_eval.py
@@ -99,7 +99,10 @@ try:
         MeanTokenEntropy,
         Perplexity,
     )
-    from lm_polygraph.stat_calculators import EntropyCalculator, VLLMLogprobsExtractionCalculator
+    from lm_polygraph.stat_calculators import (
+        EntropyCalculator,
+        VLLMLogprobsExtractionCalculator,
+    )
     from lm_polygraph.utils import VLLMWithUncertainty
 
     POLYGRAPH_UNCERTAINTY_AVAILABLE = True
@@ -542,16 +545,24 @@ def create_model(config):
                     # PD-Gap scoring using top-k logprobs matrix
                     from thinkbooster.scorers.estimator_uncertainty_pd import PDGap
 
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(output_matrix=True)]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(output_matrix=True)
+                    ]
                     estimator = PDGap()
                 elif scorer_type == "entropy":
                     # Entropy-based scoring
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(),
+                        EntropyCalculator(),
+                    ]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "prm":
                     # PRM scorer uses its own model for scoring
                     # Use entropy wrapper for generation (scores not used for selection)
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(),
+                        EntropyCalculator(),
+                    ]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "uhead":
                     from luh import AutoUncertaintyHead
@@ -822,14 +833,22 @@ def create_model(config):
                 elif scorer_type == "uncertainty_pd":
                     from thinkbooster.scorers.estimator_uncertainty_pd import PDGap
 
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(output_matrix=True)]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(output_matrix=True)
+                    ]
                     estimator = PDGap()
                 elif scorer_type == "entropy":
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(),
+                        EntropyCalculator(),
+                    ]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "prm":
                     # PRM uses its own model; use entropy for generation scoring
-                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
+                    stat_calculators = [
+                        VLLMLogprobsExtractionCalculator(),
+                        EntropyCalculator(),
+                    ]
                     estimator = MeanTokenEntropy()
                 else:
                     stat_calculators = None

--- a/scripts/run_tts_eval.py
+++ b/scripts/run_tts_eval.py
@@ -99,7 +99,7 @@ try:
         MeanTokenEntropy,
         Perplexity,
     )
-    from lm_polygraph.stat_calculators import EntropyCalculator, VLLMLogprobsCalculator
+    from lm_polygraph.stat_calculators import EntropyCalculator, VLLMLogprobsExtractionCalculator
     from lm_polygraph.utils import VLLMWithUncertainty
 
     POLYGRAPH_UNCERTAINTY_AVAILABLE = True
@@ -532,26 +532,26 @@ def create_model(config):
                 scorer_type = config.scorer.type if config.scorer else "entropy"
                 vllm_with_uncertainty_arguments = {}
                 if scorer_type == "perplexity":
-                    stat_calculators = [VLLMLogprobsCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator()]
                     estimator = Perplexity()
                 elif scorer_type == "sequence_prob":
                     # Sequence probability scoring (sum of log-probs, not normalized)
-                    stat_calculators = [VLLMLogprobsCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator()]
                     estimator = MaximumSequenceProbability()
                 elif scorer_type == "uncertainty_pd":
                     # PD-Gap scoring using top-k logprobs matrix
                     from thinkbooster.scorers.estimator_uncertainty_pd import PDGap
 
-                    stat_calculators = [VLLMLogprobsCalculator(output_matrix=True)]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(output_matrix=True)]
                     estimator = PDGap()
                 elif scorer_type == "entropy":
                     # Entropy-based scoring
-                    stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "prm":
                     # PRM scorer uses its own model for scoring
                     # Use entropy wrapper for generation (scores not used for selection)
-                    stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "uhead":
                     from luh import AutoUncertaintyHead
@@ -814,22 +814,22 @@ def create_model(config):
             scorer_type = config.scorer.type if config.scorer else None
             if supports_logprobs and scorer_type and POLYGRAPH_UNCERTAINTY_AVAILABLE:
                 if scorer_type == "perplexity":
-                    stat_calculators = [VLLMLogprobsCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator()]
                     estimator = Perplexity()
                 elif scorer_type == "sequence_prob":
-                    stat_calculators = [VLLMLogprobsCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator()]
                     estimator = MaximumSequenceProbability()
                 elif scorer_type == "uncertainty_pd":
                     from thinkbooster.scorers.estimator_uncertainty_pd import PDGap
 
-                    stat_calculators = [VLLMLogprobsCalculator(output_matrix=True)]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(output_matrix=True)]
                     estimator = PDGap()
                 elif scorer_type == "entropy":
-                    stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
                     estimator = MeanTokenEntropy()
                 elif scorer_type == "prm":
                     # PRM uses its own model; use entropy for generation scoring
-                    stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+                    stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
                     estimator = MeanTokenEntropy()
                 else:
                     stat_calculators = None

--- a/service_app/core/strategy_manager.py
+++ b/service_app/core/strategy_manager.py
@@ -75,7 +75,7 @@ class StrategyManager:
         from lm_polygraph.estimators import MeanTokenEntropy
         from lm_polygraph.stat_calculators import (
             EntropyCalculator,
-            VLLMLogprobsCalculator,
+            VLLMLogprobsExtractionCalculator,
         )
         from lm_polygraph.utils import VLLMWithUncertainty
         from vllm import LLM
@@ -127,7 +127,7 @@ class StrategyManager:
         self._current_reasoning_effort = effective_reasoning_effort
         llm = LLM(**llm_kwargs)
 
-        stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+        stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
         estimator = MeanTokenEntropy()
         self._vllm_model = VLLMWithUncertainty(
             llm=llm, stat_calculators=stat_calculators, estimator=estimator
@@ -226,7 +226,7 @@ class StrategyManager:
             )
             from lm_polygraph.stat_calculators import (
                 EntropyCalculator,
-                VLLMLogprobsCalculator,
+                VLLMLogprobsExtractionCalculator,
             )
             from lm_polygraph.utils import APIWithUncertainty
         except ImportError:
@@ -237,13 +237,13 @@ class StrategyManager:
             return base_model
 
         if scorer_type == "perplexity":
-            stat_calculators = [VLLMLogprobsCalculator()]
+            stat_calculators = [VLLMLogprobsExtractionCalculator()]
             estimator = Perplexity()
         elif scorer_type == "sequence_prob":
-            stat_calculators = [VLLMLogprobsCalculator()]
+            stat_calculators = [VLLMLogprobsExtractionCalculator()]
             estimator = MaximumSequenceProbability()
         elif scorer_type in ("entropy", "uncertainty"):
-            stat_calculators = [VLLMLogprobsCalculator(), EntropyCalculator()]
+            stat_calculators = [VLLMLogprobsExtractionCalculator(), EntropyCalculator()]
             estimator = MeanTokenEntropy()
         else:
             return base_model

--- a/service_app/core/visual_debugger_demo.py
+++ b/service_app/core/visual_debugger_demo.py
@@ -292,7 +292,7 @@ def get_debugger_runtime_health() -> Dict[str, Any]:
                 "lm_polygraph.estimators:MeanTokenEntropy",
                 "lm_polygraph.estimators:MaximumSequenceProbability",
                 "lm_polygraph.stat_calculators:EntropyCalculator",
-                "lm_polygraph.stat_calculators:VLLMLogprobsCalculator",
+                "lm_polygraph.stat_calculators:VLLMLogprobsExtractionCalculator",
                 "lm_polygraph.utils:APIWithUncertainty",
             ],
         ),

--- a/tests/test_lm_polygraph_symbols.py
+++ b/tests/test_lm_polygraph_symbols.py
@@ -1,0 +1,168 @@
+"""Canary tests for lm_polygraph symbol stability.
+
+thinkbooster imports many symbols from ``lm_polygraph``, often lazily
+(inside functions) or guarded by ``try/except ImportError``. When
+lm_polygraph is upgraded, a renamed or removed symbol will silently
+disable the affected code path without breaking any other test — this is
+exactly how the ``VLLMLogprobsCalculator`` -> ``VLLMLogprobsExtractionCalculator``
+rename in lm_polygraph 0.6.0 slipped through CI.
+
+This module lists every ``lm_polygraph`` symbol that thinkbooster depends
+on. If any rename or removal happens upstream, a targeted test case fails
+loudly and points at the source file that uses it.
+
+When adding a new ``from lm_polygraph import ...`` anywhere in the
+codebase, add a matching entry to ``SYMBOLS`` below.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+# (module, attribute, used_by) — used_by appears in the failure message
+# so the root cause is obvious from CI output alone.
+SYMBOLS: list[tuple[str, str, str]] = [
+    # thinkbooster/generators/api.py
+    (
+        "lm_polygraph.utils.api_with_uncertainty",
+        "APIWithUncertainty",
+        "thinkbooster/generators/api.py",
+    ),
+    # thinkbooster/generators/huggingface.py, scripts/run_tts_eval.py
+    ("lm_polygraph", "WhiteboxModel", "thinkbooster/generators/huggingface.py"),
+    # thinkbooster/generators/vllm.py, service_app/core/strategy_manager.py
+    ("lm_polygraph.utils", "VLLMWithUncertainty", "thinkbooster/generators/vllm.py"),
+    # thinkbooster/models/blackboxmodel_with_streaming.py,
+    # thinkbooster/strategies/deepconf/strategy.py
+    (
+        "lm_polygraph",
+        "BlackboxModel",
+        "thinkbooster/models/blackboxmodel_with_streaming.py",
+    ),
+    (
+        "lm_polygraph.utils.generation_parameters",
+        "GenerationParameters",
+        "thinkbooster/models/blackboxmodel_with_streaming.py",
+    ),
+    # thinkbooster/strategies/deepconf/utils.py
+    (
+        "lm_polygraph.estimators",
+        "MaximumTokenProbability",
+        "thinkbooster/strategies/deepconf/utils.py",
+    ),
+    (
+        "lm_polygraph.utils.token_restoration",
+        "Categorical",
+        "thinkbooster/strategies/deepconf/utils.py",
+    ),
+    # thinkbooster/scorers/multi_scorer.py,
+    # scripts/run_tts_eval.py, service_app/core/strategy_manager.py
+    (
+        "lm_polygraph.stat_calculators",
+        "VLLMLogprobsExtractionCalculator",
+        "thinkbooster/scorers/multi_scorer.py",
+    ),
+    (
+        "lm_polygraph.stat_calculators",
+        "EntropyCalculator",
+        "thinkbooster/scorers/multi_scorer.py",
+    ),
+    # thinkbooster/scorers/estimator_uncertainty_pd.py
+    (
+        "lm_polygraph.estimators.estimator",
+        "Estimator",
+        "thinkbooster/scorers/estimator_uncertainty_pd.py",
+    ),
+    # thinkbooster/scorers/step_scorer_prm.py
+    (
+        "lm_polygraph.stat_calculators",
+        "StatCalculator",
+        "thinkbooster/scorers/step_scorer_prm.py",
+    ),
+    (
+        "lm_polygraph.stat_calculators.extract_claims",
+        "Claim",
+        "thinkbooster/scorers/step_scorer_prm.py",
+    ),
+    # scripts/run_tts_eval.py, service_app/core/strategy_manager.py
+    (
+        "lm_polygraph.estimators",
+        "MaximumSequenceProbability",
+        "scripts/run_tts_eval.py",
+    ),
+    ("lm_polygraph.estimators", "MeanTokenEntropy", "scripts/run_tts_eval.py"),
+    ("lm_polygraph.estimators", "Perplexity", "scripts/run_tts_eval.py"),
+    ("lm_polygraph.utils", "APIWithUncertainty", "scripts/run_tts_eval.py"),
+    (
+        "lm_polygraph.model_adapters",
+        "WhiteboxModelvLLM",
+        "scripts/run_tts_eval.py",
+    ),
+    # thinkbooster/evaluation/alignscore.py (optional — alignscore extra)
+    (
+        "lm_polygraph.generation_metrics.alignscore_utils",
+        "AlignScorer",
+        "thinkbooster/evaluation/alignscore.py",
+    ),
+    (
+        "lm_polygraph.generation_metrics.generation_metric",
+        "GenerationMetric",
+        "thinkbooster/evaluation/alignscore.py",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "module_path,attribute,used_by",
+    SYMBOLS,
+    ids=[f"{m}.{a}" for m, a, _ in SYMBOLS],
+)
+def test_lm_polygraph_symbol_exists(
+    module_path: str, attribute: str, used_by: str
+) -> None:
+    """Every lm_polygraph symbol used in thinkbooster must resolve.
+
+    If the parent module itself cannot be imported (e.g. optional extra
+    not installed), the test is skipped — we only want to fail on renames
+    and removals, not on missing optional dependencies.
+    """
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        pytest.skip(
+            f"{module_path} is unavailable ({exc}); "
+            f"skipping — likely an optional dependency of lm_polygraph."
+        )
+    assert hasattr(module, attribute), (
+        f"{module_path}.{attribute} is missing. "
+        f"Used by {used_by}. lm_polygraph may have renamed or removed it; "
+        f"update the call site and this canary together."
+    )
+
+
+def test_multi_scorer_lazy_imports_resolve() -> None:
+    """Exercise the lazy imports in thinkbooster.scorers.multi_scorer.
+
+    The calculator factories import ``lm_polygraph`` symbols inside the
+    function body. Without this test, a rename in lm_polygraph silently
+    breaks runtime scoring while every other unit test stays green.
+    """
+    pytest.importorskip("lm_polygraph.stat_calculators")
+
+    from thinkbooster.scorers import multi_scorer
+
+    # Reset module-level caches so we test the actual import path,
+    # not a cached instance from an earlier test run.
+    multi_scorer._calc_basic = None
+    multi_scorer._calc_matrix = None
+    multi_scorer._calc_entropy = None
+
+    basic = multi_scorer._get_basic_calculator()
+    matrix = multi_scorer._get_matrix_calculator()
+    entropy = multi_scorer._get_entropy_calculator()
+
+    assert type(basic).__name__ == "VLLMLogprobsExtractionCalculator"
+    assert type(matrix).__name__ == "VLLMLogprobsExtractionCalculator"
+    assert type(entropy).__name__ == "EntropyCalculator"

--- a/thinkbooster/scorers/multi_scorer.py
+++ b/thinkbooster/scorers/multi_scorer.py
@@ -37,18 +37,18 @@ _estimator_pd_gap = None
 def _get_basic_calculator():
     global _calc_basic
     if _calc_basic is None:
-        from lm_polygraph.stat_calculators import VLLMLogprobsCalculator
+        from lm_polygraph.stat_calculators import VLLMLogprobsExtractionCalculator
 
-        _calc_basic = VLLMLogprobsCalculator(output_matrix=False)
+        _calc_basic = VLLMLogprobsExtractionCalculator(output_matrix=False)
     return _calc_basic
 
 
 def _get_matrix_calculator():
     global _calc_matrix
     if _calc_matrix is None:
-        from lm_polygraph.stat_calculators import VLLMLogprobsCalculator
+        from lm_polygraph.stat_calculators import VLLMLogprobsExtractionCalculator
 
-        _calc_matrix = VLLMLogprobsCalculator(output_matrix=True)
+        _calc_matrix = VLLMLogprobsExtractionCalculator(output_matrix=True)
     return _calc_matrix
 
 


### PR DESCRIPTION
## Summary
`lm-polygraph` 0.6.0 (our pinned minimum in `pyproject.toml`) renamed `VLLMLogprobsCalculator` → `VLLMLogprobsExtractionCalculator`. The old symbol no longer exists, so every code path that imports it crashes at runtime. Reported by @artemshelmanov.

- **Fix:** renamed all 21 usages across 4 files.
  - `thinkbooster/scorers/multi_scorer.py`
  - `scripts/run_tts_eval.py`
  - `service_app/core/strategy_manager.py`
  - `service_app/core/visual_debugger_demo.py`
- **Formatting:** `scripts/run_tts_eval.py` rewrapped by `black` — the longer class name pushed several lines past 88 chars.
- **Canary test (`tests/test_lm_polygraph_symbols.py`):** enumerates every `lm_polygraph` symbol thinkbooster imports (18 cases) with `used_by` pointers. A rename or removal upstream now fails CI loudly instead of silently disabling features. Also exercises the lazy imports inside `thinkbooster.scorers.multi_scorer` so function-body imports are actually executed under pytest.

## Why this slipped through CI the first time
Three things teamed up to hide the bug after the `llm_tts` → `thinkbooster` rename merged:
1. **All the broken imports are lazy or swallowed.** `multi_scorer.py` imports inside `_get_basic_calculator()` / `_get_matrix_calculator()`; `run_tts_eval.py` wraps the block in `try: ... except ImportError: POLYGRAPH_UNCERTAINTY_AVAILABLE = False`; `strategy_manager.py` imports inside instance methods, one also inside a `try/except ImportError` that just logs a warning. Module import therefore always succeeds.
2. **Zero tests touched those code paths.** `grep -rn multi_scorer tests/` returned nothing — no unit test ever instantiated these calculators, so the lazy imports were never triggered under `pytest`.
3. **mypy is blinded too.** `pyproject.toml` has `lm_polygraph.*` in `ignore_missing_imports`, so static checks can't flag the missing symbol either.

The canary + lazy-import exercise test close all three gaps.

## Test plan
- [x] Verified PyPI `lm-polygraph==0.6.0` exports only `VLLMLogprobsExtractionCalculator` (downloaded the wheel, inspected `stat_calculators/__init__.py`)
- [x] Triggered the lazy imports in `thinkbooster.scorers.multi_scorer` locally — `_get_basic_calculator`, `_get_matrix_calculator`, `_get_entropy_calculator` all instantiate successfully
- [x] `grep -rn VLLMLogprobsCalculator` is empty after the rename
- [x] `black --check`, `isort --check-only`, `flake8` all clean
- [x] `pytest tests/test_lm_polygraph_symbols.py -v` — all 19 tests pass
- [x] Negative test: monkey-patched the canary with the old `VLLMLogprobsCalculator` name and confirmed it fails with `lm_polygraph.stat_calculators.VLLMLogprobsCalculator is missing. Used by thinkbooster/scorers/multi_scorer.py.`
- [ ] Full `scripts/run_tts_eval.py` smoke run on a GPU box (post-merge, before cutting v0.1.2)