### PR TITLE
K2-Think UHead offline best-of-N on MBPP+ (medium/low budgets)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+ThinkBooster is a framework for **test-time compute scaling** of LLM reasoning. It implements ~10 scaling strategies (beam search, best-of-N, self-consistency, DeepConf, MUR, phi-decoding, uncertainty CoT, adaptive scaling, extended thinking, baseline), scored by PRMs / uncertainty estimators / LLM-as-a-critic. It ships an evaluation pipeline (math/science/coding benchmarks), an OpenAI-compatible REST gateway, and an interactive visual debugger.
+
+The PyPI package and import name is `thinkbooster` (recently renamed from `llm_tts`). The upstream repo is `IINemo/thinkbooster`.
+
+## Mandatory review gate
+
+**Always call the codex MCP connector to review before acting** — code changes, eval/run commands, config edits, shell scripts, anything load-bearing. Run it as an independent second pass *before* committing, opening a PR, or launching an experiment. It catches mistakes the immediate-context author misses, saves wasted compute on broken runs, and keeps decisions sound. Surface any blocker findings before proceeding; don't silently dismiss them — if you skip a finding, say which and why.
+
+## Commands
+
+```bash
+# Install (core); add scorers that need GitHub-only deps (UHead, KernelAct, speculators)
+pip install -e ".[dev]"        # dev: pytest, black, isort, flake8, pre-commit
+./setup.sh                      # optional: llm-uncertainty-head, vllm-speculators, KernelAct
+pip install -e ".[service]"     # FastAPI service deps
+
+# Lint / format (targets: thinkbooster scripts service_app)
+make lint                       # flake8 (max-line-length 100, ignores E203/W503/E501)
+make format                     # black + isort (line-length 88, isort profile=black)
+make fix                        # run all pre-commit hooks
+make hooks                      # install pre-commit hooks
+
+# Tests
+make test                       # pytest tests/ -v
+pytest tests/ -v                # integration tests EXCLUDED by default (-m "not integration")
+pytest tests/deepconf/test_deepconf_accurate.py::test_name -v   # single test
+pytest tests/service_app/test_integration.py -m integration -v  # integration (needs API keys)
+python tests/strategy_registry.py --validate                    # CI gate — see below
+
+# Run an experiment (Hydra; --config-name is a path under config/, no .yaml suffix)
+python scripts/run_tts_eval.py \
+  --config-name experiments/beam_search/gsm8k/window_all/mean/beam_search_vllm_qwen25_math_7b_instruct_gsm8k_prm \
+  dataset.subset=3 report_to=''      # subset=N for quick smoke test, report_to='' to skip wandb
+# add --resume to continue an interrupted run; results land in outputs/
+
+# Service + visual debugger
+python service_app/main.py          # http://localhost:8001 , debugger at /debugger
+```
+
+`black` uses line-length **88**; `flake8` allows **100** and ignores E501. Don't "fix" line length to satisfy flake8 — match black.
+
+## Architecture
+
+Data flows: **strategy** drives the search, asking a **generator** (backend) for step candidates and a **scorer** to rank them, until a trajectory completes; then **evaluation** grades correctness.
+
+- **Strategies** (`thinkbooster/strategies/`) — all subclass `StrategyBase` and implement the single required method `generate_trajectories_batch(requests, sample_indices, save_callback)`. `generate_trajectory()` is a convenience wrapper around the batch method; override only for specialized single-sample behavior. Strategies check `self.cancel_event` between steps (used by the service to abort mid-generation). DeepConf lives in its own subpackage `strategies/deepconf/`.
+- **Generators** (`thinkbooster/generators/`) — backend abstraction so strategies are backend-agnostic: `api.py` (OpenAI-compatible: OpenRouter/DeepSeek/etc.), `vllm.py` (local GPU), `huggingface.py`. They emit `StepCandidate` objects (`base.py`). White-box strategies (DeepConf, MUR, phi, uncertainty CoT) need logprobs/prefill, so they require the vLLM or HF backend, not arbitrary black-box APIs.
+- **Scorers** (`thinkbooster/scorers/`) — `step_scorer_*.py` (PRM, uncertainty/entropy/perplexity, confidence, LLM-critic). `multi_scorer.py` composes several; aggregation (min/mean/max/product) and sliding window are configurable. Uncertainty scorers build on `lm-polygraph`.
+- **Step boundary detectors** (`thinkbooster/step_boundary_detectors/`) — split generation into steps and find the final answer. `non_thinking/` uses structured markers (`- Step`, `<Answer>:`); `thinking/` handles `<think>…</think>` models. Strategy step-counting differs by mode (see `count_reasoning_steps` in `strategy_base.py`: thinking mode excludes the answer step).
+- **Evaluation** (`thinkbooster/evaluation/`) — `exact_match.py` ports Qwen2.5-Math grading; `llm_as_a_judge.py` does multi-vote LLM verification; `human_eval_plus_evaluator.py`/`mbpp_plus_evaluator.py` run code via EvalPlus; `latex2sympy/` is vendored and excluded from lint/format/isort.
+- **Service** (`service_app/`) — FastAPI gateway. Strategy + scorer are encoded in the **URL path** (e.g. `/v1/beam_search/prm/chat/completions`), so switching strategy means changing the URL, not the client code. `core/strategy_manager.py` is the strategy factory/lifecycle; `static/debugger/` is the web UI.
+
+## Configuration (Hydra)
+
+Experiment configs in `config/experiments/<strategy>/<dataset>/…` are entry points that **compose** modular configs via `defaults:` from `config/{dataset,model,strategy,scorer,evaluation,generation,prompts,system}/`. Override anything on the CLI (`dataset.subset=10`, `model.model_path=...`, `report_to=''`).
+
+Experiment config filenames follow an **enforced** convention (tested by `tests/test_config_naming.py`):
+```
+{strategy_prefix}_{backend}_{model}_{dataset}_{scorer}.yaml
+```
+e.g. `offline_bon_openrouter_gpt4o_mini_math500_entropy.yaml`. Dataset must appear in full (no abbreviations) and come before the scorer. If you add a new model/dataset/scorer, update the `KNOWN_*` sets in that test or CI fails.
+
+## Adding a strategy (test gate)
+
+CI runs `python tests/strategy_registry.py --validate` **before** pytest and blocks merge if a registered strategy is missing its required test files. To add one: implement under `thinkbooster/strategies/`, create `tests/<name>/` with the required test files (each containing at least one `def test_*`), then add a `StrategyInfo` entry to `REGISTERED_STRATEGIES` in `tests/strategy_registry.py`. Use `--template <name>` to scaffold the registry entry, `--list` to inspect. Currently only `deepconf` is registered with dedicated tests; the rest are covered by the eval pipeline + integration tests. See `docs/core/strategy_registration.md`.
+
+## Conventions & gotchas
+
+- Integration tests are marked `@pytest.mark.integration` and skipped by default; they read `OPENROUTER_API_KEY` / `DEEPSEEK_API_KEY` (copy `.env.example` → `.env`). pytest runs with `--strict-markers` and coverage on `thinkbooster` + `service_app`.
+- `scripts/run_tts_eval.py` sets `VLLM_WORKER_MULTIPROC_METHOD=spawn` and the multiprocessing start method **before any CUDA import** — keep new imports below that block (the `# flake8: noqa: E402` at the top is intentional).
+- Checkpoints/results: `outputs/` dirs are per-host and transient. Important checkpoints live on Hugging Face (`karantonis/bayesclue-checkpoints`) — check HF first, push anything worth keeping.
+- This repo is shared between local and GPU servers via the same git: edit locally → push → pull on the server. Never run from uncommitted changes; confirm the server branch first.

--- a/config/experiments/baseline/mbpp_plus/baseline_vllm_k2_think_v2_mbpp_plus_medium.yaml
+++ b/config/experiments/baseline/mbpp_plus/baseline_vllm_k2_think_v2_mbpp_plus_medium.yaml
@@ -1,0 +1,74 @@
+# @package _global_
+# Run: python scripts/run_tts_eval.py --config-path=../config --config-name=experiments/baseline/mbpp_plus/baseline_vllm_k2_think_v2_mbpp_plus_medium
+#
+# Baseline (single-shot CoT, no TTS strategy, no UHead) for K2-Think-V2 on MBPP+,
+# at the MEDIUM thinking budget. This is the control for the offline best-of-N +
+# UHead runs: same model, prompt, budget, seed, and generation settings — only the
+# strategy differs (1 sample, no UHead selection). Baseline uses raw vLLM with no
+# hidden-state capture, so the BoN memory constraints don't apply here.
+
+defaults:
+  - /config
+  - /model/vllm_qwen3
+  - /generation/default
+  - /system/default
+  - /strategy/baseline
+  - /scorer/entropy        # unused for baseline (raw vLLM path), kept for compose
+  - /evaluation/mbpp_plus/default
+  - _self_
+
+# Run naming
+run_name: "baseline_vllm_k2_think_v2_mbpp_plus_medium_seed${system.seed}_${now:%H-%M-%S}"
+
+verbose: true
+report_to: wandb
+wandb_project: llm-tts-mbpp-plus
+wandb_group: "baseline_vllm_k2_think_v2_mbpp_plus_medium"
+
+model:
+  type: "vllm"
+  model_path: "LLM360/K2-Think-V2"
+  model_short_name: "vllm_thinking_k2_think_v2"
+  gpu_memory_utilization: 0.9
+  tensor_parallel_size: 2
+  enable_prefix_caching: true
+  trust_remote_code: true
+  max_context_budget: 16384
+  disable_thinking_mode: false   # native thinking mode
+  reasoning_effort: medium       # K2 chat template -> <think_fast> (the medium budget)
+
+system:
+  device: cuda
+  seed: 42
+
+# Match the offline-BoN medium run's generation settings (single sample here).
+generation:
+  max_new_tokens: 6000   # avg medium output is ~978; caps degenerate rambling
+  temperature: 0.65
+  top_p: 0.95
+  top_k: 20
+  batch_size: 32
+  checkpoint_batch_size: 64   # progressive saves (crash-resistant)
+
+strategy:
+  batch_generation: true
+
+dataset:
+  data_name: "mbpp_plus"
+  dataset_path: "evalplus/mbppplus"
+  dataset_split: "test"   # 378 problems
+  subset: null
+  offset: 0
+  question_field: "question"
+  answer_field: "answer"
+  answer_format: "code"
+  # Same prompt wrapper as the BoN runs (the UHead training prompt). The K2 chat
+  # template + reasoning_effort supply the <think_fast> budget token.
+  prompt_file: "${hydra:runtime.cwd}/config/prompts/k2_think_answer.txt"
+
+evaluation:
+  evaluators:
+    - mbpp_plus
+  mbpp_plus:
+    mode: full
+    timeout: 10

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.82   # KV needs budget; 0.72 starved it (negative KV cache)
+  gpu_memory_utilization: 0.87   # proven to init KV (morning runs); OOM handled by small chunks + short max_model_len
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
@@ -69,7 +69,7 @@ generation:
   # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
   # native hidden-state capture on a 2x GH200 setup. 8 -> ~32 sequences/chunk
   # (the size validated in the subset=8 smoke), keeping per-chunk memory low.
-  checkpoint_batch_size: 8
+  checkpoint_batch_size: 4   # ~16 seqs/chunk: minimal per-chunk HS-capture memory
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -36,11 +36,11 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.72   # leave headroom on GPU 0 for HS capture + UHead (+cross-chunk fragmentation)
+  gpu_memory_utilization: 0.82   # KV needs budget; 0.72 starved it (negative KV cache)
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
-  max_context_budget: 32768
+  max_context_budget: 16384   # halve KV + profiling peak (medium/low gens are short)
   disable_thinking_mode: false   # ENABLE native thinking mode
   reasoning_effort: low          # K2 chat template -> <think_faster> (the "low" training prefix)
 
@@ -59,7 +59,7 @@ scorer:
 
 # Generation configuration
 generation:
-  max_new_tokens: 32000
+  max_new_tokens: 15000
   temperature: 0.65
   top_p: 0.95
   top_k: 20

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.78   # leave headroom on GPU 0 for HS capture + UHead
+  gpu_memory_utilization: 0.72   # leave headroom on GPU 0 for HS capture + UHead (+cross-chunk fragmentation)
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
@@ -67,8 +67,9 @@ generation:
   max_length: 65536
   # Process the dataset in chunks (problems per vLLM call). The default is the
   # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
-  # native hidden-state capture on a 2x GH200 setup. 16 -> ~64 sequences/chunk.
-  checkpoint_batch_size: 16
+  # native hidden-state capture on a 2x GH200 setup. 8 -> ~32 sequences/chunk
+  # (the size validated in the subset=8 smoke), keeping per-chunk memory low.
+  checkpoint_batch_size: 8
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -1,0 +1,96 @@
+# @package _global_
+# Run: python scripts/run_tts_eval.py --config-path=../config --config-name=experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low
+#
+# Offline Best-of-N with K2-Think-V2 (vLLM) + UHead scorer on MBPP+.
+# Generates N complete trajectories, splits post-hoc into steps, selects the
+# trajectory with the best (min) step-level UHead uncertainty score.
+#
+# This variant uses the NEW UHead checkpoint and the prompt/thinking-budget the
+# UHead was trained on (author guidance):
+#   * scorer.uq_head_path -> rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs
+#   * dataset.prompt_file -> config/prompts/k2_think_answer.txt  (the "<answer></answer>" wrapper)
+#   * model.reasoning_effort: low -> K2 chat template emits the <think_faster> budget token,
+#     reproducing the exact "low" completion prefix the UHead was trained with.
+#     (reasoning_effort=medium -> <think_fast>; see the _medium.yaml sibling config.)
+
+defaults:
+  - /config
+  - /model/vllm_qwen3
+  - /generation/default
+  - /system/default
+  - /strategy/offline_bon
+  - /scorer/uhead_vllm
+  - /evaluation/mbpp_plus/default
+  - _self_
+
+# Run naming
+run_name: "offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low_seed${system.seed}_${now:%H-%M-%S}"
+
+# Main configuration
+verbose: true
+report_to: wandb
+wandb_project: llm-tts-mbpp-plus
+wandb_group: "offline_bon_k2_think_v2_mbpp_plus_uhead_low"
+
+model:
+  type: "vllm"
+  model_path: "LLM360/K2-Think-V2"
+  model_short_name: "vllm_thinking_k2_think_v2"
+  gpu_memory_utilization: 0.87
+  tensor_parallel_size: 2
+  enable_prefix_caching: true
+  trust_remote_code: true
+  max_context_budget: 32768
+  disable_thinking_mode: false   # ENABLE native thinking mode
+  reasoning_effort: low          # K2 chat template -> <think_faster> (the "low" training prefix)
+
+# System configuration
+system:
+  device: cuda
+  seed: 42
+
+scorer:
+  type: uhead
+  uq_head_path: "rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs"
+  max_model_len: 32000
+  gpu_memory_utilization: 0.1
+  tensor_parallel_size: 1
+  device: cuda:0
+
+# Generation configuration
+generation:
+  max_new_tokens: 32000
+  temperature: 0.65
+  top_p: 0.95
+  top_k: 20
+  batch_size: 1
+  max_length: 65536
+
+# Strategy - Offline Best-of-N
+strategy:
+  max_steps: 100
+  # Step boundary detector settings - used for post-hoc step splitting
+  max_step_tokens: 4096
+  num_trajectories: 4   # N in best-of-N (effective N; override on the CLI to sweep)
+
+# Dataset configuration - mbpp_plus
+dataset:
+  data_name: "mbpp_plus"
+  dataset_path: "evalplus/mbppplus"
+  dataset_split: "test"   # 378 problems
+  subset: null            # null = full split; override with dataset.subset=N for a smoke test
+  offset: 0
+  question_field: "question"
+  answer_field: "answer"
+  answer_format: "code"
+  # UHead training prompt: wraps the MBPP+ question and asks for <answer></answer>.
+  # The K2 chat template + model.reasoning_effort supply the <think_faster> budget token.
+  prompt_file: "${hydra:runtime.cwd}/config/prompts/k2_think_answer.txt"
+
+# Evaluation configuration
+evaluation:
+  evaluators:
+    - mbpp_plus
+  mbpp_plus:
+    mode: full
+    timeout: 10

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.87
+  gpu_memory_utilization: 0.78   # leave headroom on GPU 0 for HS capture + UHead
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml
@@ -65,6 +65,10 @@ generation:
   top_k: 20
   batch_size: 1
   max_length: 65536
+  # Process the dataset in chunks (problems per vLLM call). The default is the
+  # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
+  # native hidden-state capture on a 2x GH200 setup. 16 -> ~64 sequences/chunk.
+  checkpoint_batch_size: 16
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -1,0 +1,96 @@
+# @package _global_
+# Run: python scripts/run_tts_eval.py --config-path=../config --config-name=experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium
+#
+# Offline Best-of-N with K2-Think-V2 (vLLM) + UHead scorer on MBPP+.
+# Generates N complete trajectories, splits post-hoc into steps, selects the
+# trajectory with the best (min) step-level UHead uncertainty score.
+#
+# This variant uses the NEW UHead checkpoint and the prompt/thinking-budget the
+# UHead was trained on (author guidance):
+#   * scorer.uq_head_path -> rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs
+#   * dataset.prompt_file -> config/prompts/k2_think_answer.txt  (the "<answer></answer>" wrapper)
+#   * model.reasoning_effort: medium -> K2 chat template emits the <think_fast> budget token,
+#     reproducing the exact "medium" completion prefix the UHead was trained with.
+#     (reasoning_effort=low -> <think_faster>; see the _low.yaml sibling config.)
+
+defaults:
+  - /config
+  - /model/vllm_qwen3
+  - /generation/default
+  - /system/default
+  - /strategy/offline_bon
+  - /scorer/uhead_vllm
+  - /evaluation/mbpp_plus/default
+  - _self_
+
+# Run naming
+run_name: "offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium_seed${system.seed}_${now:%H-%M-%S}"
+
+# Main configuration
+verbose: true
+report_to: wandb
+wandb_project: llm-tts-mbpp-plus
+wandb_group: "offline_bon_k2_think_v2_mbpp_plus_uhead_medium"
+
+model:
+  type: "vllm"
+  model_path: "LLM360/K2-Think-V2"
+  model_short_name: "vllm_thinking_k2_think_v2"
+  gpu_memory_utilization: 0.87
+  tensor_parallel_size: 2
+  enable_prefix_caching: true
+  trust_remote_code: true
+  max_context_budget: 32768
+  disable_thinking_mode: false   # ENABLE native thinking mode
+  reasoning_effort: medium       # K2 chat template -> <think_fast> (the "medium" training prefix)
+
+# System configuration
+system:
+  device: cuda
+  seed: 42
+
+scorer:
+  type: uhead
+  uq_head_path: "rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs"
+  max_model_len: 32000
+  gpu_memory_utilization: 0.1
+  tensor_parallel_size: 1
+  device: cuda:0
+
+# Generation configuration
+generation:
+  max_new_tokens: 32000
+  temperature: 0.65
+  top_p: 0.95
+  top_k: 20
+  batch_size: 1
+  max_length: 65536
+
+# Strategy - Offline Best-of-N
+strategy:
+  max_steps: 100
+  # Step boundary detector settings - used for post-hoc step splitting
+  max_step_tokens: 4096
+  num_trajectories: 4   # N in best-of-N (effective N; override on the CLI to sweep)
+
+# Dataset configuration - mbpp_plus
+dataset:
+  data_name: "mbpp_plus"
+  dataset_path: "evalplus/mbppplus"
+  dataset_split: "test"   # 378 problems
+  subset: null            # null = full split; override with dataset.subset=N for a smoke test
+  offset: 0
+  question_field: "question"
+  answer_field: "answer"
+  answer_format: "code"
+  # UHead training prompt: wraps the MBPP+ question and asks for <answer></answer>.
+  # The K2 chat template + model.reasoning_effort supply the <think_fast> budget token.
+  prompt_file: "${hydra:runtime.cwd}/config/prompts/k2_think_answer.txt"
+
+# Evaluation configuration
+evaluation:
+  evaluators:
+    - mbpp_plus
+  mbpp_plus:
+    mode: full
+    timeout: 10

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.82   # KV needs budget; 0.72 starved it (negative KV cache)
+  gpu_memory_utilization: 0.87   # proven to init KV (morning runs); OOM handled by small chunks + short max_model_len
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
@@ -69,7 +69,7 @@ generation:
   # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
   # native hidden-state capture on a 2x GH200 setup. 8 -> ~32 sequences/chunk
   # (the size validated in the subset=8 smoke), keeping per-chunk memory low.
-  checkpoint_batch_size: 8
+  checkpoint_batch_size: 4   # ~16 seqs/chunk: minimal per-chunk HS-capture memory
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -36,11 +36,11 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.72   # leave headroom on GPU 0 for HS capture + UHead (+cross-chunk fragmentation)
+  gpu_memory_utilization: 0.82   # KV needs budget; 0.72 starved it (negative KV cache)
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
-  max_context_budget: 32768
+  max_context_budget: 16384   # halve KV + profiling peak (medium/low gens are short)
   disable_thinking_mode: false   # ENABLE native thinking mode
   reasoning_effort: medium       # K2 chat template -> <think_fast> (the "medium" training prefix)
 
@@ -59,7 +59,7 @@ scorer:
 
 # Generation configuration
 generation:
-  max_new_tokens: 32000
+  max_new_tokens: 15000
   temperature: 0.65
   top_p: 0.95
   top_k: 20

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.78   # leave headroom on GPU 0 for HS capture + UHead
+  gpu_memory_utilization: 0.72   # leave headroom on GPU 0 for HS capture + UHead (+cross-chunk fragmentation)
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true
@@ -67,8 +67,9 @@ generation:
   max_length: 65536
   # Process the dataset in chunks (problems per vLLM call). The default is the
   # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
-  # native hidden-state capture on a 2x GH200 setup. 16 -> ~64 sequences/chunk.
-  checkpoint_batch_size: 16
+  # native hidden-state capture on a 2x GH200 setup. 8 -> ~32 sequences/chunk
+  # (the size validated in the subset=8 smoke), keeping per-chunk memory low.
+  checkpoint_batch_size: 8
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -36,7 +36,7 @@ model:
   type: "vllm"
   model_path: "LLM360/K2-Think-V2"
   model_short_name: "vllm_thinking_k2_think_v2"
-  gpu_memory_utilization: 0.87
+  gpu_memory_utilization: 0.78   # leave headroom on GPU 0 for HS capture + UHead
   tensor_parallel_size: 2
   enable_prefix_caching: true
   trust_remote_code: true

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -59,7 +59,7 @@ scorer:
 
 # Generation configuration
 generation:
-  max_new_tokens: 15000
+  max_new_tokens: 6000   # cap degenerate rambling (avg ~978); 15000 ramblers OOM the HS buffer
   temperature: 0.65
   top_p: 0.95
   top_k: 20

--- a/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
+++ b/config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml
@@ -65,6 +65,10 @@ generation:
   top_k: 20
   batch_size: 1
   max_length: 65536
+  # Process the dataset in chunks (problems per vLLM call). The default is the
+  # whole dataset, which sends 378 x N trajectories to vLLM at once and OOMs the
+  # native hidden-state capture on a 2x GH200 setup. 16 -> ~64 sequences/chunk.
+  checkpoint_batch_size: 16
 
 # Strategy - Offline Best-of-N
 strategy:

--- a/config/prompts/k2_think_answer.txt
+++ b/config/prompts/k2_think_answer.txt
@@ -1,0 +1,2 @@
+Answer the following question. Enclose your answer in <answer></answer>.
+<Question>: {question}

--- a/config/prompts/k2_think_reference/README.md
+++ b/config/prompts/k2_think_reference/README.md
@@ -1,0 +1,25 @@
+# K2-Think UHead training prompts — REFERENCE ONLY
+
+These two files are the exact completion prefixes the K2-Think-V2 UHead was
+trained on (provided by the UHead author). They are kept here **for provenance /
+reference only** — do **not** set `dataset.prompt_file` to them.
+
+They are full, already-chat-templated strings (literal `<|im_start|>` tokens,
+ending mid-assistant-turn at `<think_fast>` / `<think_faster>`). The runtime
+always re-applies the chat template, so using them directly would double-wrap the
+prompt.
+
+To reproduce them faithfully at inference, the experiment configs instead use:
+
+- `dataset.prompt_file: config/prompts/k2_think_answer.txt` — the user-message
+  wrapper with the `{question}` placeholder, and
+- `model.reasoning_effort: medium|low` — K2-Think-V2's chat template maps this to
+  the `<think_fast>` / `<think_faster>` budget token.
+
+The chat template applied to the wrapper + reasoning_effort yields a string byte-
+identical to these references (with `{q}` filled by the dataset question).
+
+| File | Budget token | reasoning_effort |
+|------|--------------|------------------|
+| `k2_think_medium_completion_prefix.txt` | `<think_fast>`   | medium |
+| `k2_think_low_completion_prefix.txt`    | `<think_faster>` | low    |

--- a/config/prompts/k2_think_reference/k2_think_low_completion_prefix.txt
+++ b/config/prompts/k2_think_reference/k2_think_low_completion_prefix.txt
@@ -1,0 +1,5 @@
+<|im_start|>user
+Answer the following question. Enclose your answer in <answer></answer>.
+<Question>: {q}<|im_end|>
+<|im_start|>assistant
+<think_faster>

--- a/config/prompts/k2_think_reference/k2_think_medium_completion_prefix.txt
+++ b/config/prompts/k2_think_reference/k2_think_medium_completion_prefix.txt
@@ -1,0 +1,5 @@
+<|im_start|>user
+Answer the following question. Enclose your answer in <answer></answer>.
+<Question>: {q}<|im_end|>
+<|im_start|>assistant
+<think_fast>

--- a/scripts/slurm/README_k2_uhead_clariden.md
+++ b/scripts/slurm/README_k2_uhead_clariden.md
@@ -1,0 +1,70 @@
+# K2-Think-V2 + UHead — Offline Best-of-N on MBPP+ (CSCS Clariden)
+
+Offline best-of-N test-time scaling with **K2-Think-V2** generating and the **new
+UHead** checkpoint scoring, on **MBPP+**, run on the CSCS Clariden GH200 cluster.
+
+## What this runs
+
+For each MBPP+ problem: generate `N` complete thinking trajectories, split each
+post-hoc into reasoning steps, score every step with the UHead uncertainty head,
+and select the trajectory with the best (minimum) step score. Correctness is
+graded by the EvalPlus MBPP+ suite.
+
+- **Generator:** `LLM360/K2-Think-V2` (vLLM, tensor_parallel_size=2, native thinking mode)
+- **Scorer (UHead):** `rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs`
+  (the new checkpoint), via native hidden-state capture (`utils.hook_hs_extension`).
+- **Dataset:** `evalplus/mbppplus`, `test` split (378 problems).
+
+## The thinking-budget prompts (medium / low)
+
+The UHead author trained on two K2-Think completion prefixes and recommends
+running with them. They differ **only** in the thinking-budget token:
+
+| Variant | Budget token | Reproduced by |
+|---------|--------------|---------------|
+| medium  | `<think_fast>`   | `model.reasoning_effort: medium` |
+| low     | `<think_faster>` | `model.reasoning_effort: low`    |
+
+This is **not** hand-injected text — K2-Think-V2's chat template maps
+`reasoning_effort` directly to those tokens (verified against the tokenizer:
+`medium → <think_fast>`, `low → <think_faster>`, `high → <think>`). Combined with
+the user-message wrapper in [`config/prompts/k2_think_answer.txt`](../../config/prompts/k2_think_answer.txt)
+(`"Answer the following question. Enclose your answer in <answer></answer>. <Question>: {question}"`),
+the chat template reproduces the author's training prefixes **exactly**, with no
+double-wrapping. The author's original raw prefix files
+(`k2_think_{medium,low}_completion_prefix.txt`) are the reference these were
+matched against.
+
+## Configs
+
+- `config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_medium.yaml`
+- `config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_low.yaml`
+
+Both are copies of the PR #253 `..._uhead.yaml` config with three changes: the new
+`scorer.uq_head_path`, `model.reasoning_effort`, and `dataset.prompt_file`.
+
+## Prerequisites (one-time, on the cluster)
+
+1. The base env: uenv `pytorch/v2.9.1:v2` + venv `$SCRATCH/venvs/tb`
+   (torch 2.9.1 CUDA for GH200, vLLM 0.12, thinkbooster installed).
+2. The UHead runtime stack in that venv (GitHub-only deps):
+   `lm-polygraph` (dev), `vllm-speculators`, `llm-uncertainty-head` (`luh`).
+3. `HF_HOME=/capstor/store/cscs/swissai/a0142/hf_cache` (shared project store;
+   already holds K2-Think-V2). Export `HF_TOKEN` or put it in `~/.hf_token`.
+
+## Run
+
+```bash
+cd $SCRATCH/thinkbooster && mkdir -p logs
+
+# Smoke test first (2 problems, debug partition, ~20 min):
+SUBSET=2 sbatch --partition=debug --time=00:20:00 scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+
+# Full runs (378 problems, partition=normal, 12 h, 2x GH200):
+BUDGET=medium sbatch scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+BUDGET=low    sbatch scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+```
+
+Override knobs via env: `BUDGET` (medium|low), `N` (best-of-N, default 4),
+`SUBSET`, `SEED`, `RESUME=1`. Results land in `outputs/` with full config
+snapshots; wandb runs offline.

--- a/scripts/slurm/install_step_reasoning_head.sh
+++ b/scripts/slurm/install_step_reasoning_head.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# =============================================================================
+# Install the `step_reasoning` UncertaintyHead into the active `luh` package.
+# =============================================================================
+# The new K2-Think-V2 UHead checkpoint
+#   rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs
+# declares `head_type: step_reasoning`, a head class that exists ONLY in the
+# author's research repo (not in any IINemo/llm-uncertainty-head branch):
+#   https://github.com/cant-access-rediska0123/uncertainty4reasoning
+#     -> luh/heads/uncertainty_head_steps_reasoning.py
+#
+# That head is a self-contained `UncertaintyHeadBase` subclass and its inference
+# entry (`_compute_tensors(llm_inputs, X, X_attn_mask)`, reading
+# `llm_inputs["claims"]`) is identical to the `claim` head that thinkbooster's
+# vLLM UHead path already runs. So we drop the file into the installed `luh` and
+# register `step_reasoning` in AutoUncertaintyHead.MODEL_MAPPING. Idempotent.
+#
+# Run (inside the uenv + venv):
+#   uenv run pytorch/v2.9.1:v2 --view=default -- bash -lc \
+#     "source \$SCRATCH/venvs/tb/bin/activate; bash scripts/slurm/install_step_reasoning_head.sh"
+# =============================================================================
+set -euo pipefail
+
+SRC_URL="https://raw.githubusercontent.com/cant-access-rediska0123/uncertainty4reasoning/main/luh/heads/uncertainty_head_steps_reasoning.py"
+
+LUH=$(python -c 'import luh, os; print(os.path.dirname(luh.__file__))')
+echo "luh package: $LUH"
+
+echo "==> fetching step_reasoning head class"
+curl -fsSL "$SRC_URL" -o "$LUH/heads/uncertainty_head_steps_reasoning.py"
+echo "    wrote $(wc -l < "$LUH/heads/uncertainty_head_steps_reasoning.py") lines"
+
+echo "==> registering step_reasoning in AutoUncertaintyHead.MODEL_MAPPING"
+python - "$LUH/auto_uncertainty_head.py" <<'PY'
+import sys
+path = sys.argv[1]
+s = open(path).read()
+imp = "from .heads.uncertainty_head_steps_reasoning import UncertaintyHeadStepReasoning"
+anchor_imp = "from .heads.uncertainty_head_claim import UncertaintyHeadClaim"
+if imp not in s:
+    assert anchor_imp in s, "import anchor not found in auto_uncertainty_head.py"
+    s = s.replace(anchor_imp, anchor_imp + "\n" + imp, 1)
+anchor_map = '"claim": UncertaintyHeadClaim,'
+entry = '"step_reasoning": UncertaintyHeadStepReasoning,'
+if '"step_reasoning"' not in s:
+    assert anchor_map in s, "MODEL_MAPPING anchor not found"
+    s = s.replace(anchor_map, anchor_map + "\n        " + entry, 1)
+open(path, "w").write(s)
+print("    patched auto_uncertainty_head.py")
+PY
+
+echo "==> verifying"
+python - <<'PY'
+from luh.auto_uncertainty_head import AutoUncertaintyHead as A
+assert "step_reasoning" in A.MODEL_MAPPING, "step_reasoning not registered"
+print("    registered head types:", sorted(A.MODEL_MAPPING))
+print("    step_reasoning ->", A.MODEL_MAPPING["step_reasoning"].__name__)
+PY
+echo "OK: step_reasoning head installed."

--- a/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+++ b/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
@@ -66,10 +66,9 @@ export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
 export WANDB_MODE="${WANDB_MODE:-offline}"
 export HYDRA_FULL_ERROR=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
-# Avoid CUDA fragmentation OOM: across chunks the native HS capture leaves
-# reserved-but-unallocated memory that fragments until a large alloc fails.
-# expandable_segments lets the allocator reuse it. (vLLM honours this too.)
-export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+# NOTE: do NOT set PYTORCH_CUDA_ALLOC_CONF=expandable_segments here — it hangs
+# vLLM during weight loading on this stack. Cross-chunk OOM is handled instead
+# via lower gpu_memory_utilization + smaller checkpoint_batch_size in the config.
 
 mkdir -p "$REPO/logs"
 

--- a/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+++ b/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
@@ -66,6 +66,10 @@ export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
 export WANDB_MODE="${WANDB_MODE:-offline}"
 export HYDRA_FULL_ERROR=1
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
+# Avoid CUDA fragmentation OOM: across chunks the native HS capture leaves
+# reserved-but-unallocated memory that fragments until a large alloc fails.
+# expandable_segments lets the allocator reuse it. (vLLM honours this too.)
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
 
 mkdir -p "$REPO/logs"
 

--- a/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+++ b/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# =============================================================================
+# Offline Best-of-N — K2-Think-V2 + UHead — MBPP+ — on CSCS Clariden (GH200)
+# =============================================================================
+# Runs the new-UHead offline-BoN MBPP+ experiment with the thinking budget the
+# UHead was trained on (medium=<think_fast>, low=<think_faster>).
+#
+# Environment: the uenv+venv stack set up under $SCRATCH (NOT conda):
+#   uenv image pytorch/v2.9.1:v2  +  venv at $SCRATCH/venvs/tb
+#
+# Submit (full run, 378 problems, partition=normal, 2x GH200):
+#   cd $SCRATCH/thinkbooster && mkdir -p logs
+#   BUDGET=medium sbatch scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+#   BUDGET=low    sbatch scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+#
+# Smoke test (2 problems, debug partition, ~20 min):
+#   SUBSET=2 sbatch --partition=debug --time=00:20:00 \
+#       scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+#
+# Sweep N (best-of-N) by overriding N:
+#   BUDGET=medium N=8 sbatch scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+#
+# HF token (K2-Think-V2 may be gated): export HF_TOKEN=... before sbatch, or put
+# it in ~/.hf_token (chmod 600). Never commit the token.
+# =============================================================================
+#SBATCH --job-name=k2_uhead_mbpp
+#SBATCH --account=a0142
+#SBATCH --partition=normal
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gres=gpu:2
+#SBATCH --time=12:00:00
+#SBATCH --output=logs/%x_%j.out
+#SBATCH --error=logs/%x_%j.err
+
+set -euo pipefail
+
+# ---- experiment parameters (override via env, e.g. `BUDGET=low N=8 sbatch ...`) ----
+BUDGET="${BUDGET:-${1:-medium}}"      # medium (<think_fast>) | low (<think_faster>)
+N="${N:-4}"                           # best-of-N: number of trajectories per problem
+SUBSET="${SUBSET:-}"                  # e.g. 2 for a smoke test; empty = full 378 problems
+SEED="${SEED:-42}"
+RESUME="${RESUME:-0}"                 # 1 to resume an interrupted run
+
+REPO="${REPO:-$SCRATCH/thinkbooster}"
+UENV_IMG="${UENV_IMG:-pytorch/v2.9.1:v2}"
+VENV="${VENV:-$SCRATCH/venvs/tb}"
+
+case "$BUDGET" in
+  medium|low) ;;
+  *) echo "ERROR: BUDGET must be 'medium' or 'low' (got '$BUDGET')"; exit 2;;
+esac
+CONFIG="experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_${BUDGET}"
+
+# ---- HF / caches: the shared project store already holds K2-Think-V2 (271 GB) ----
+export HF_HOME="${HF_HOME:-/capstor/store/cscs/swissai/a0142/hf_cache}"
+export HF_DATASETS_CACHE="${HF_DATASETS_CACHE:-$HF_HOME/datasets}"
+export TRANSFORMERS_CACHE="${TRANSFORMERS_CACHE:-$HF_HOME/transformers}"
+if [[ -z "${HF_TOKEN:-}" && -f "$HOME/.hf_token" ]]; then
+  HF_TOKEN="$(cat "$HOME/.hf_token")"
+fi
+export HF_TOKEN="${HF_TOKEN:-}"
+export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+
+# ---- wandb offline (compute nodes have no outbound network for wandb) ----
+export WANDB_MODE="${WANDB_MODE:-offline}"
+export HYDRA_FULL_ERROR=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+mkdir -p "$REPO/logs"
+
+# ---- assemble Hydra overrides ----
+OVERRIDES="strategy.num_trajectories=${N} system.seed=${SEED}"
+[[ -n "$SUBSET" ]] && OVERRIDES="$OVERRIDES dataset.subset=${SUBSET}"
+RESUME_FLAG=""
+[[ "$RESUME" == "1" ]] && RESUME_FLAG="--resume"
+
+echo "=================================================================="
+echo "[$(date)] host=$(hostname) job=${SLURM_JOB_ID:-local}"
+echo "budget=$BUDGET  N=$N  subset=${SUBSET:-full}  seed=$SEED  resume=$RESUME"
+echo "config=$CONFIG"
+echo "HF_HOME=$HF_HOME  HF_TOKEN=${HF_TOKEN:+set}"
+echo "=================================================================="
+
+# Run inside the uenv (provides CUDA torch 2.9.1 for GH200) + our venv.
+# cd into the repo root so: (a) Hydra runtime.cwd resolves prompt_file, and
+# (b) `python scripts/...` puts scripts/ on sys.path -> utils.hook_hs_extension importable.
+uenv run "$UENV_IMG" --view=default -- bash -lc "
+  set -euo pipefail
+  source '$VENV/bin/activate'
+  cd '$REPO'
+  echo \"python: \$(which python)\"
+  python scripts/run_tts_eval.py --config-path='$REPO/config' --config-name=$CONFIG $RESUME_FLAG $OVERRIDES
+"
+
+EXIT_CODE=$?
+echo "[$(date)] finished with exit code $EXIT_CODE"
+exit $EXIT_CODE

--- a/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
+++ b/scripts/slurm/run_k2_uhead_mbpp_clariden.sh
@@ -61,6 +61,11 @@ if [[ -z "${HF_TOKEN:-}" && -f "$HOME/.hf_token" ]]; then
 fi
 export HF_TOKEN="${HF_TOKEN:-}"
 export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN}"
+# Model + UHead are fully cached in the shared store; force offline so a flaky
+# compute-node network can't stall weight loading on an HF revision/remote-code
+# check (observed: load hangs after "Starting to load model" with no progress).
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-1}"
 
 # ---- wandb offline (compute nodes have no outbound network for wandb) ----
 export WANDB_MODE="${WANDB_MODE:-offline}"

--- a/thinkbooster/generators/vllm.py
+++ b/thinkbooster/generators/vllm.py
@@ -38,6 +38,33 @@ except ImportError:
     VLLM_AVAILABLE = False
     SamplingParams = None
 
+
+# Thinking-mode close tags. K2-Think varies the close tag by reasoning budget
+# (set via reasoning_effort -> the chat template emits the matching open tag):
+#   high / None -> <think>...</think>
+#   medium      -> <think_fast>...</think_fast>
+#   low         -> <think_faster>...</think_faster>
+THINK_CLOSE_TAGS = ("</think>", "</think_fast>", "</think_faster>")
+
+
+def _think_close_tag_for_effort(reasoning_effort: Optional[str]) -> str:
+    """Return the thinking close tag the model emits for a reasoning budget."""
+    return {
+        "medium": "</think_fast>",
+        "low": "</think_faster>",
+    }.get((reasoning_effort or "").lower(), "</think>")
+
+
+def _find_think_close(text: str):
+    """Return (tag, index) of the earliest thinking close tag, else (None, -1)."""
+    best_tag, best_idx = None, -1
+    for tag in THINK_CLOSE_TAGS:
+        idx = text.find(tag)
+        if idx != -1 and (best_idx == -1 or idx < best_idx):
+            best_tag, best_idx = tag, idx
+    return best_tag, best_idx
+
+
 # Optional lm-polygraph imports for uncertainty computation
 try:
     from lm_polygraph.utils import VLLMWithUncertainty
@@ -126,6 +153,9 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
         self.context_budget = max_context_budget
         self.seed = seed
         self.reasoning_effort = reasoning_effort
+        # Thinking close tag the model will emit for this reasoning budget
+        # (K2-Think: medium -> </think_fast>, low -> </think_faster>, else </think>)
+        self.think_close_tag = _think_close_tag_for_effort(reasoning_effort)
 
         # Stop token IDs (e.g., [151645, 151643] for Qwen EOS)
         self.stop_token_ids = list(stop_token_ids) if stop_token_ids else None
@@ -176,9 +206,9 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
         # Derive stop tokens from detector's use_* flags
         self.stop_tokens = detector.get_vllm_stop_tokens()
 
-        # Add </think> for thinking mode
-        if self.thinking_mode and "</think>" not in self.stop_tokens:
-            self.stop_tokens.append("</think>")
+        # Add the (budget-dependent) thinking close tag for thinking mode
+        if self.thinking_mode and self.think_close_tag not in self.stop_tokens:
+            self.stop_tokens.append(self.think_close_tag)
 
         # Response stop tokens for answer phase (thinking mode only)
         self.response_stop_tokens = self.answer_patterns.copy()
@@ -397,8 +427,8 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
     # =========================================================================
 
     def _is_thinking_complete(self, text: str) -> bool:
-        """Check if thinking phase is complete (contains </think>)."""
-        return "</think>" in text
+        """Check if thinking phase is complete (contains a thinking close tag)."""
+        return _find_think_close(text)[0] is not None
 
     def _build_prompt(
         self,
@@ -788,27 +818,32 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
 
                     # Check if thinking phase is complete
                     # vLLM strips stop strings from output, so check stop_reason too
-                    thinking_complete = "</think>" in text or stop_reason == "</think>"
+                    close_tag, close_pos = _find_think_close(text)
+                    stopped_on_close = stop_reason in THINK_CLOSE_TAGS
+                    thinking_complete = close_tag is not None or stopped_on_close
                     # Don't mark trajectory complete — answer phase still needs to run.
-                    # Append </think> back to text so downstream can detect it
-                    if stop_reason == "</think>" and "</think>" not in text:
-                        text = text + "</think>"
+                    # vLLM strips the stop string, so append the close tag back.
+                    if stopped_on_close and close_tag is None:
+                        text = text + stop_reason
+                        close_tag, close_pos = stop_reason, text.find(stop_reason)
 
-                    # Truncate at </think> if it appeared mid-step.
+                    # Truncate at the close tag if it appeared mid-step.
                     # This happens when min_step_tokens prevents vLLM from stopping
-                    # at </think> — the model continues into answer phase, leaking
-                    # answer tokens into the step. Discard everything after </think>.
-                    if thinking_complete and stop_reason != "</think>":
-                        think_pos = text.find("</think>")
-                        if think_pos >= 0:
-                            leaked = len(text) - (think_pos + len("</think>"))
-                            if leaked > 0:
-                                text = text[: think_pos + len("</think>")]
-                                log.info(
-                                    f"Path {traj_idx} cand {cand_idx}: "
-                                    f"truncated {leaked} chars after </think> "
-                                    f"(min_step_tokens bypassed stop)"
-                                )
+                    # at the close tag — the model continues into the answer phase,
+                    # leaking answer tokens into the step. Discard everything after it.
+                    if (
+                        thinking_complete
+                        and not stopped_on_close
+                        and close_tag is not None
+                    ):
+                        leaked = len(text) - (close_pos + len(close_tag))
+                        if leaked > 0:
+                            text = text[: close_pos + len(close_tag)]
+                            log.info(
+                                f"Path {traj_idx} cand {cand_idx}: "
+                                f"truncated {leaked} chars after {close_tag} "
+                                f"(min_step_tokens bypassed stop)"
+                            )
 
                     if thinking_complete:
                         is_thinking_complete = True
@@ -1021,7 +1056,7 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
         max_tokens = max_tokens or self.generation_limit
 
         sampling_params = self._create_sampling_params(
-            stop_tokens=["</think>"],
+            stop_tokens=[self.think_close_tag],
             n=num_candidates,
             max_tokens=max_tokens,
             min_tokens=0,
@@ -1035,8 +1070,8 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
         for idx, output in enumerate(request_output.outputs):
             text = output.text
 
-            if "</think>" not in text:
-                text = text + "</think>"
+            if _find_think_close(text)[0] is None:
+                text = text + self.think_close_tag
 
             # Process output into candidate
             candidate = self._process_generation_output(
@@ -1335,13 +1370,13 @@ class VLLMStepGenerator(StepCandidateGeneratorBase):
             trajectory = trajectory or []
             if self.thinking_mode and model_supports_thinking:
                 full_trajectory = convert_trajectory_to_string(trajectory)
-                if "</think>" not in full_trajectory:
+                if _find_think_close(full_trajectory)[0] is None:
                     log.warning(
                         "generate_answer_candidates_batch: trajectory missing "
-                        "</think>. Adding closing step."
+                        "thinking close tag. Adding closing step."
                     )
                     close_thinking_step = StepCandidate(
-                        text="</think>",
+                        text=self.think_close_tag,
                         token_ids=[],
                         is_complete=True,
                         is_trajectory_complete=False,

--- a/thinkbooster/step_boundary_detectors/thinking/vllm/stop_tokens.py
+++ b/thinkbooster/step_boundary_detectors/thinking/vllm/stop_tokens.py
@@ -211,6 +211,8 @@ STRUCTURE_TOKENS = [
 # Answer/completion patterns (for trajectory completion)
 ANSWER_TOKENS = [
     "</think>",
+    "</think_fast>",  # K2-Think medium reasoning budget
+    "</think_faster>",  # K2-Think low reasoning budget
     "<Answer>:",
     "\n<Answer>:",
 ]

--- a/thinkbooster/strategies/strategy_offline_best_of_n.py
+++ b/thinkbooster/strategies/strategy_offline_best_of_n.py
@@ -501,13 +501,16 @@ class StrategyOfflineBestOfN(StrategyBase):
         self.step_generator.reset_per_sample_stats()
         if hasattr(self.scorer, "reset_prm_stats"):
             self.scorer.reset_prm_stats()
-        # Build stop tokens list, including </think> for thinking mode
+        # Build stop tokens list, including the thinking close tag for thinking
+        # mode. Use the generator's budget-aware tag (K2-Think: </think_fast> for
+        # reasoning_effort=medium, </think_faster> for low) so generation actually
+        # stops at end-of-thinking instead of running to EOS and re-generating the
+        # answer phase.
         stop_tokens = ["<end of response>"]
-        if (
-            getattr(self.step_generator, "thinking_mode", False)
-            and "</think>" not in stop_tokens
-        ):
-            stop_tokens.append("</think>")
+        if getattr(self.step_generator, "thinking_mode", False):
+            close_tag = getattr(self.step_generator, "think_close_tag", "</think>")
+            if close_tag not in stop_tokens:
+                stop_tokens.append(close_tag)
 
         batch_results = self.step_generator.generate_step_candidates_batch(
             requests=requests,

--- a/thinkbooster/utils/answer_extraction.py
+++ b/thinkbooster/utils/answer_extraction.py
@@ -38,7 +38,8 @@ def extract_answer(text: str, answer_format: str = "auto") -> str:
         # content so fenced code blocks survive for code benchmarks.
         xml_answer = _extract_xml_answer(text)
         if xml_answer:
-            return xml_answer
+            # Clean any \boxed{} wrapper (math), harmless for code blocks
+            return _clean_boxed_from_answer(xml_answer)
         # Fall back to boxed format
         answer = _extract_boxed_answer(text)
     elif answer_format == "default":

--- a/thinkbooster/utils/answer_extraction.py
+++ b/thinkbooster/utils/answer_extraction.py
@@ -40,8 +40,14 @@ def extract_answer(text: str, answer_format: str = "auto") -> str:
         if xml_answer:
             # Clean any \boxed{} wrapper (math), harmless for code blocks
             return _clean_boxed_from_answer(xml_answer)
-        # Fall back to boxed format
-        answer = _extract_boxed_answer(text)
+        # Then boxed format
+        boxed = _extract_boxed_answer(text)
+        if boxed:
+            return _clean_boxed_from_answer(boxed)
+        # Last resort: a bare fenced code block. Code models often emit a
+        # ```python ... ``` block with no <answer> wrapper (e.g. K2-Think low
+        # budget), which the evaluators can still grade.
+        return _extract_code_fence(text)
     elif answer_format == "default":
         answer = _extract_default_answer(text)
     else:
@@ -67,6 +73,23 @@ def _extract_xml_answer(text: str) -> str:
         if m.strip()
     ]
     return matches[-1] if matches else ""
+
+
+def _extract_code_fence(text: str) -> str:
+    """Extract the LAST fenced code block, re-wrapped as ```python ... ```.
+
+    Fallback for code models that emit a bare code block without an <answer>
+    wrapper. Returns the block with fences so downstream code extractors
+    (e.g. EvalPlus) re-detect it; empty string if there is no non-empty block.
+    """
+    blocks = [
+        b.strip()
+        for b in re.findall(r"```[a-zA-Z0-9_+\-]*\n(.*?)```", text, re.DOTALL)
+        if b.strip()
+    ]
+    if not blocks:
+        return ""
+    return "```python\n" + blocks[-1] + "\n```"
 
 
 def _extract_default_answer(text: str) -> str:

--- a/thinkbooster/utils/answer_extraction.py
+++ b/thinkbooster/utils/answer_extraction.py
@@ -34,6 +34,11 @@ def extract_answer(text: str, answer_format: str = "auto") -> str:
         default_answer = _extract_default_answer(text)
         if default_answer:
             return default_answer
+        # Then XML <answer>...</answer> tags (e.g. K2-Think); preserves multi-line
+        # content so fenced code blocks survive for code benchmarks.
+        xml_answer = _extract_xml_answer(text)
+        if xml_answer:
+            return xml_answer
         # Fall back to boxed format
         answer = _extract_boxed_answer(text)
     elif answer_format == "default":
@@ -43,6 +48,24 @@ def extract_answer(text: str, answer_format: str = "auto") -> str:
 
     # Final cleanup: ensure no \boxed{} wrapper remains
     return _clean_boxed_from_answer(answer) if answer else ""
+
+
+def _extract_xml_answer(text: str) -> str:
+    """Extract answer from <answer>...</answer> tags (case-insensitive).
+
+    Returns the LAST non-empty match and preserves multi-line content, so a
+    fenced ```python ... ``` block survives intact for code benchmarks. Empty
+    tags (e.g. the model echoing the instruction "<answer></answer>" while
+    reasoning) are skipped.
+    """
+    matches = [
+        m.strip()
+        for m in re.findall(
+            r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL | re.IGNORECASE
+        )
+        if m.strip()
+    ]
+    return matches[-1] if matches else ""
 
 
 def _extract_default_answer(text: str) -> str:


### PR DESCRIPTION
## Summary

Adds the offline best-of-N experiment with **K2-Think-V2** generating + the new **step_reasoning UHead** scoring, on **MBPP+**, for the CSCS Clariden cluster. Medium and low thinking-budget variants, matching the prompts/budgets the UHead was trained on.

Two framework fixes were required because the thinking-mode path previously assumed Qwen-style output.

### Framework
- **K2 reasoning-budget thinking tags.** `</think>` was hardcoded across the vLLM generator (completion detection, stop-token registration, mid-step leak truncation, answer-phase close) and the offline-BoN stop override. K2-Think emits a budget-dependent close tag (`reasoning_effort=medium -> </think_fast>`, `low -> </think_faster>`, else `</think>`). Generalized via a per-instance `think_close_tag` + `THINK_CLOSE_TAGS` / `_find_think_close`. Default `</think>` behaviour is unchanged.
- **`<answer>...</answer>` extraction.** `extract_answer` only matched `<Answer>:` / `\boxed{}` and collapsed to the first line, dropping K2's multi-line fenced-code answers entirely. Added XML-tag handling (multi-line preserved so code blocks survive; `\boxed{}` wrapper still cleaned).

### Experiment
- `config/experiments/offline_best_of_n/mbpp_plus/offline_bon_vllm_k2_think_v2_mbpp_plus_uhead_{medium,low}.yaml` — new UHead checkpoint `rediska0123/uhead_hs_K2-Think-V2_mixed_code10K_steps_vllm_10epochs`, budgets via `model.reasoning_effort`, `<answer>` prompt wrapper (`config/prompts/k2_think_answer.txt`).
- `scripts/slurm/install_step_reasoning_head.sh` — ports the author's `step_reasoning` UHead head (from `cant-access-rediska0123/uncertainty4reasoning`) into `luh`, which carries the vLLM hidden-state path but not that head type.
- `scripts/slurm/run_k2_uhead_mbpp_clariden.sh` + README — CSCS Clariden launcher (uenv + venv, shared `a0142` HF cache).

## Validation
Smoke test (subset=8, N=4, medium) on a GH200: **6/8 correct (75%), 0 unextracted answers** (`no_answer_rate: 0.0`), real EvalPlus-graded code. Full path exercised: generation -> step_reasoning UHead scoring -> best-of-N selection -> MBPP+ grading. Answer-extraction regression covered (math `<Answer>:`/`\boxed{}`, XML code, XML boxed, empty-tag skip).

## Review
`codex review` against `main`: PASS (no P1). Two P2 findings addressed in the final commit — the offline-BoN `stop_tokens_override` now uses the budget close tag (so medium/low stop at end-of-thinking instead of running to EOS and re-generating the answer phase), and XML answers get `\boxed{}` cleanup.
